### PR TITLE
Add CI dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,32 @@ jobs:
           name: coverage-reports-${{ matrix.node-version }}
           path: packages/*/coverage
 
+  dependency_audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --production --audit-level=high
+
+      - name: List outdated dependencies
+        run: npm outdated || true
+
   post_coverage_comment:
     name: Post Coverage Comment
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you'd like to get early feedback on your work, please use GitHub's **Draft Pu
 
 #### 4. Ensure All Checks Pass
 
-Before submitting your PR, ensure that all automated checks are passing by running `npm run preflight`. This command runs all tests, linting, and other style checks.
+Before submitting your PR, ensure that all automated checks are passing by running `npm run preflight`. This command runs all tests, linting, and other style checks. The CI workflow also performs a dependency audit on pull requests using `npm audit --production --audit-level=high` and lists outdated packages with `npm outdated`.
 
 #### 5. Update Documentation
 


### PR DESCRIPTION
## Summary
- run `npm audit` and `npm outdated` on PRs
- document new dependency audit check in CONTRIBUTING

## Testing
- `npm run preflight` *(fails: ENOTFOUND registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2d9c3448322b477f61a5f1a30c5